### PR TITLE
go.mod: Upgrade to Go 1.24

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version: "1.24"
       - name: Build
         run: go build -v ./...
       - name: Test

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,9 +1,11 @@
 ---
+version: "2"
+
 run:
   timeout: 5m
 
 linters:
-  disable-all: true
+  default: none
   # enable:
   #   - mirror
   #   - errcheck
@@ -33,7 +35,7 @@ linters:
     - copyloopvar
     # - cyclop # Fires on things where we need the cyclomatic complexity.
     - decorder
-    - depguard
+    # - depguard # Fires on tests where we import our own package.
     - dogsled
     - dupl
     - dupword
@@ -48,7 +50,6 @@ linters:
     - fatcontext
     - forbidigo
     - forcetypeassert
-    - gci
     - ginkgolinter
     - gocheckcompilerdirectives
     # - gochecknoglobals
@@ -60,15 +61,11 @@ linters:
     - gocyclo
     # - godot # This is just silly.
     # - godox # Fires too often on things that will eventually be fixed.
-    - gofmt
-    - gofumpt
     - goheader
-    - goimports
     - gomoddirectives
     - gomodguard
     - goprintffuncname
     # - gosec # Too many false positives, where truncation is desired.
-    - gosimple
     - gosmopolitan
     - govet
     - grouper
@@ -107,10 +104,8 @@ linters:
     - spancheck
     - sqlclosecheck
     - staticcheck
-    - stylecheck
     - tagalign
     - tagliatelle
-    - tenv
     - testableexamples
     - testifylint
     - testpackage
@@ -126,14 +121,14 @@ linters:
     - zerologlint
     # - gosec # too many false positives
 
-linters-settings:
-  lll:
-    line-length: 200
-  misspell:
-    locale: US
+  settings:
+    lll:
+      line-length: 200
+    misspell:
+      locale: US
 
-issues:
-  exclude-rules:
-    - path: '(.+)_test\.go'
-      linters:
-        - wrapcheck
+  exclusions:
+    rules:
+      - path: '(.+)_test\.go'
+        linters:
+          - wrapcheck

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ This gives us a powerful abstraction that "does the right thing" behind the scen
 
 ## Go Version Support
 
-I'm supporting the latest Go major version - 2, which seems to be the policy several other large projects are following.
-As this library was originally built for use in one of those bigger projects, I've adopted an appropriate support policy to ensure it's compatible.
+I'm currently supporting the latest Go major version.
+Previously, I'd aimed to support the current major version - 2, but there's a world of performance and features availble on Go 1.24+, and I'd like to have access to those things.
+The larger open source project that this library was originally developed for has caught up to at least Go 1.23+, so this library should be usable for them soon.
 

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,5 @@
 module github.com/philipaconrad/gzipstreamwriter
 
-go 1.21
-
-toolchain go1.23.0
+go 1.24
 
 require github.com/google/go-cmp v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,2 @@
-github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
-github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=

--- a/gzipstreamwriter_test.go
+++ b/gzipstreamwriter_test.go
@@ -14,14 +14,14 @@ import (
 )
 
 var testGzipWriterPool = sync.Pool{
-	New: func() interface{} {
+	New: func() any {
 		writer := gzip.NewWriter(io.Discard)
 		return writer
 	},
 }
 
 var testGzipReaderPool = sync.Pool{
-	New: func() interface{} {
+	New: func() any {
 		reader := new(gzip.Reader)
 		return reader
 	},
@@ -40,10 +40,10 @@ func TestClose(t *testing.T) {
 		if !ok {
 			t.Fatal("Could not get *gzip.Writer instance from the pool.")
 		}
-		defer expGzipWriter.Close()
+		defer expGzipWriter.Close() //nolint:errcheck
 		defer testGzipWriterPool.Put(expGzipWriter)
 		expGzipWriter.Reset(&expBuffer)
-		expGzipWriter.Close()
+		_ = expGzipWriter.Close()
 
 		actGzipWriter := gzipstreamwriter.NewGzipStreamWriter(&actBuffer)
 		if err := actGzipWriter.Close(); err != nil {
@@ -65,15 +65,15 @@ func TestClose(t *testing.T) {
 		if !ok {
 			t.Fatal("Could not get *gzip.Writer instance from the pool.")
 		}
-		defer expGzipWriter.Close()
+		defer expGzipWriter.Close() //nolint:errcheck
 		defer testGzipWriterPool.Put(expGzipWriter)
 		expGzipWriter.Reset(&expBuffer)
-		expGzipWriter.Close()
-		expGzipWriter.Close()
+		_ = expGzipWriter.Close()
+		_ = expGzipWriter.Close()
 
 		actGzipWriter := gzipstreamwriter.NewGzipStreamWriter(&actBuffer)
-		actGzipWriter.Close()
-		actGzipWriter.Close()
+		_ = actGzipWriter.Close()
+		_ = actGzipWriter.Close()
 
 		if diff := cmp.Diff(expBuffer.Bytes(), actBuffer.Bytes()); diff != "" {
 			t.Fatalf("TestClose() double-close mismatch (-want +got):\n%s", diff)
@@ -94,21 +94,21 @@ func TestFlush(t *testing.T) {
 		if !ok {
 			t.Fatal("Could not get *gzip.Writer instance from the pool.")
 		}
-		defer expGzipWriter.Close()
+		defer expGzipWriter.Close() //nolint:errcheck
 		defer testGzipWriterPool.Put(expGzipWriter)
 		expGzipWriter.Reset(&expBuffer)
-		expGzipWriter.Flush()
+		_ = expGzipWriter.Flush()
 
 		actGzipWriter := gzipstreamwriter.NewGzipStreamWriter(&actBuffer)
-		actGzipWriter.Flush()
+		_ = actGzipWriter.Flush()
 
 		if diff := cmp.Diff(expBuffer.Bytes(), actBuffer.Bytes()); diff != "" {
 			t.Fatalf("TestFlush() single-flush mismatch (-want +got):\n%s", diff)
 		}
 
 		// Close writers and ensure the trailers match.
-		expGzipWriter.Close()
-		actGzipWriter.Close()
+		_ = expGzipWriter.Close()
+		_ = actGzipWriter.Close()
 
 		if diff := cmp.Diff(expBuffer.Bytes(), actBuffer.Bytes()); diff != "" {
 			t.Fatalf("TestFlush() single-flush mismatch (-want +got):\n%s", diff)
@@ -125,23 +125,23 @@ func TestFlush(t *testing.T) {
 		if !ok {
 			t.Fatal("Could not get *gzip.Writer instance from the pool.")
 		}
-		defer expGzipWriter.Close()
+		defer expGzipWriter.Close() //nolint:errcheck
 		defer testGzipWriterPool.Put(expGzipWriter)
 		expGzipWriter.Reset(&expBuffer)
-		expGzipWriter.Flush()
-		expGzipWriter.Flush()
+		_ = expGzipWriter.Flush()
+		_ = expGzipWriter.Flush()
 
 		actGzipWriter := gzipstreamwriter.NewGzipStreamWriter(&actBuffer)
-		actGzipWriter.Flush()
-		actGzipWriter.Flush()
+		_ = actGzipWriter.Flush()
+		_ = actGzipWriter.Flush()
 
 		if diff := cmp.Diff(expBuffer.Bytes(), actBuffer.Bytes()); diff != "" {
 			t.Fatalf("TestFlush() double-flush mismatch (-want +got):\n%s", diff)
 		}
 
 		// Close writers and ensure the trailers match.
-		expGzipWriter.Close()
-		actGzipWriter.Close()
+		_ = expGzipWriter.Close()
+		_ = actGzipWriter.Close()
 
 		if diff := cmp.Diff(expBuffer.Bytes(), actBuffer.Bytes()); diff != "" {
 			t.Fatalf("TestFlush() double-flush mismatch (-want +got):\n%s", diff)
@@ -171,7 +171,6 @@ func TestWrite(t *testing.T) {
 	}
 
 	for _, tc := range testcases {
-		tc := tc // loop var copy. Not needed in Go 1.22+
 		t.Run(tc.note, func(t *testing.T) {
 			t.Parallel()
 
@@ -182,7 +181,7 @@ func TestWrite(t *testing.T) {
 			if !ok {
 				t.Fatal("Could not get *gzip.Writer instance from the pool.")
 			}
-			defer expGzipWriter.Close()
+			defer expGzipWriter.Close() //nolint:errcheck
 			defer testGzipWriterPool.Put(expGzipWriter)
 			expGzipWriter.Reset(&expBuffer)
 			actGzipWriter := gzipstreamwriter.NewGzipStreamWriter(&actBuffer)
@@ -203,7 +202,7 @@ func TestWrite(t *testing.T) {
 			if !ok {
 				t.Fatal("Could not get *gzip.Reader instance from the pool.")
 			}
-			defer gzReader.Close()
+			defer gzReader.Close() //nolint:errcheck
 			defer testGzipReaderPool.Put(gzReader)
 
 			var expResult []byte


### PR DESCRIPTION
### :nut_and_bolt: What code changed, and why?

Upgrade the toolchain to Go 1.24, and adjust the README to suit.
